### PR TITLE
Fix core frequency in config.txt to repair UART console

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -6,3 +6,4 @@ uart_2ndstage=1
 armstub=RPI_EFI.fd
 device_tree_address=0x1f0000
 device_tree_end=0x200000
+core_freq=250


### PR DESCRIPTION
I propose that we fix the core frequency to 250 MHz to repair the UART console.

Arguably, we might be losing a bit of performance here, but the UART console is so useful for debug and headless operation that I think this is well worth it. Don't hesitate to let me know if you disagree.

Best regards,
Vincent.
